### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Nico Verduin <nico.verduin@ziggo.nl>
 maintainer=Nico Verduin <nico.verduin@ziggo.nl>
 sentence=A library to support pinMode, digitalRead and digitalWrite on PCA9555 I2C IO Expander
 paragraph=Supports pinMode, digitalRead and digitalWrite
-category=Input / Output
+category=Signal Input/Output
 url=https://github.com/nicoverduin/PCA9555
 architectures=avr


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Input / Output' in library PCA9555 is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format