### PR TITLE
Fix bug for STM32

### DIFF
--- a/Examples/Example_PCA9555.ino
+++ b/Examples/Example_PCA9555.ino
@@ -17,6 +17,10 @@ PCA9555 ioport(0x20);
 void setup()
 {
 	//
+	// start I2C
+	//
+	ioport.begin();
+	//
 	// set first 14 pins to output
 	//
 	for (uint8_t i = 0; i < 14; i++){

--- a/clsPCA9555.cpp
+++ b/clsPCA9555.cpp
@@ -11,7 +11,7 @@
  * @par License info
  *
  * Class to enable the use of single pins on PCA9555 IO Expander using
- * pinMode(), digitalRead() and digitalWrite().
+ * begin(), pinMode(), digitalRead() and digitalWrite().
  *
  * Copyright (C) 2015  Nico Verduin
  *
@@ -50,6 +50,13 @@
 PCA9555::PCA9555(uint8_t address) {
     _address         = address;        // save the address id
     _valueRegister   = 0;
+}
+
+/**
+ * @name begin
+ * begin I2C
+ */
+void PCA9555::begin(void) {
     Wire.begin();                      // start I2C communication
 }
 

--- a/clsPCA9555.h
+++ b/clsPCA9555.h
@@ -33,6 +33,7 @@ enum {
 class PCA9555 {
 public:
     PCA9555(uint8_t address);                            // constructor
+    void begin(void);                                    // begin 
     void pinMode(uint8_t pin, uint8_t IOMode );          // pinMode
     uint8_t digitalRead(uint8_t pin);                    // digitalRead
     void digitalWrite(uint8_t pin, uint8_t value );      // digitalWrite

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,5 @@
 PCA9555	KEYWORD1
+begin KEYWORD2
 pinMode	KEYWORD2
 digitalRead	KEYWORD2
 digitalRead	KEYWORD2


### PR DESCRIPTION
Thank you very much for your nice project. I am using this PCA9555 I2C expander in my project. Though your library is for AVR, it should be able to work with STM32 MCU. I test it on STM32F103C with core code form [Arduino_STM32](https://github.com/rogerclarkmelbourne/Arduino_STM32) but it cannot work and shows no error when compiling. Finally I find when remove Wire.begin() to a new public member, it works. I don't know why this happen but it does work. 