### PR TITLE
Avoid undesired pulse on outputs at start

### DIFF
--- a/clsPCA9555.cpp
+++ b/clsPCA9555.cpp
@@ -52,6 +52,7 @@ PCA9555* PCA9555::instancePointer = 0;
 PCA9555::PCA9555(uint8_t address, int interruptPin) {
     _address         = address;        // save the address id
     _valueRegister   = 0;
+    _configurationRegister = 65535;
     Wire.begin();                      // start I2C communication
 
     if(interruptPin >= 0)


### PR DESCRIPTION
initial register status = 65535 to avoid undesired pulse on the outputs at start